### PR TITLE
Fix SPI build when iOS target did fail

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -13,6 +13,8 @@ builder:
     target: AdaEngine
   - platform: visionos
     target: AdaEngine
+  - platform: wasm
+    target: AdaEngine
   - platform: windows
     target: AdaEngine
   - documentation_targets: [AdaEngine, AdaEngineMacros, Math, AdaApp, AdaECS, AdaRender, AdaText, AdaUI, AdaInput]

--- a/Package.swift
+++ b/Package.swift
@@ -118,9 +118,6 @@ var products: [Product] = [
         name: "AdaWeb",
         targets: ["AdaWeb"]
     ),
-    .plugin(name: "AdaWebExportPlugin", targets: [
-        "AdaWebExportPlugin"
-    ]),
     .plugin(name: "WebGPUBuildPlugin", targets: [
         "WebGPUBuildPlugin"
     ]),
@@ -560,35 +557,43 @@ var targets: [Target] = [
     ),
 ]
 
-targets.append(
-    .executableTarget(
-        name: "AdaShaderTranspilerTool",
-        dependencies: [
-            "SPIRVCompiler"
-        ],
-        path: "Plugins/AdaShaderTranspilerTool"
+if isWebExportEnabled {
+    products.append(
+        .plugin(name: "AdaWebExportPlugin", targets: [
+            "AdaWebExportPlugin"
+        ])
     )
-)
 
-targets.append(
-    .plugin(
-        name: "AdaWebExportPlugin",
-        capability: .command(
-            intent: .custom(
-                verb: "export-web",
-                description: "Export an AdaEngine executable target as a browser WebAssembly app"
-            ),
-            permissions: [
-                .writeToPackageDirectory(reason: "Write the exported web app bundle to the requested output directory"),
-                .allowNetworkConnections(scope: .all(), reason: "Download Dawn/Tint when Tint is not installed and shaders need WGSL generation")
-            ]
-        ),
-        dependencies: [
-            .target(name: "AdaShaderTranspilerTool")
-        ],
-        path: "Plugins/AdaWebExportPlugin"
+    targets.append(
+        .executableTarget(
+            name: "AdaShaderTranspilerTool",
+            dependencies: [
+                "SPIRVCompiler"
+            ],
+            path: "Plugins/AdaShaderTranspilerTool"
+        )
     )
-)
+
+    targets.append(
+        .plugin(
+            name: "AdaWebExportPlugin",
+            capability: .command(
+                intent: .custom(
+                    verb: "export-web",
+                    description: "Export an AdaEngine executable target as a browser WebAssembly app"
+                ),
+                permissions: [
+                    .writeToPackageDirectory(reason: "Write the exported web app bundle to the requested output directory"),
+                    .allowNetworkConnections(scope: .all(), reason: "Download Dawn/Tint when Tint is not installed and shaders need WGSL generation")
+                ]
+            ),
+            dependencies: [
+                .target(name: "AdaShaderTranspilerTool")
+            ],
+            path: "Plugins/AdaWebExportPlugin"
+        )
+    )
+}
 
 targets.append(
     .plugin(

--- a/Sources/AdaEngine/Utils/AdaUIHotReloadPlugin.swift
+++ b/Sources/AdaEngine/Utils/AdaUIHotReloadPlugin.swift
@@ -7,7 +7,7 @@
 
 // swiftlint:disable file_length
 
-#if !WASM
+#if !WASM && (os(macOS) || os(Linux) || os(Windows))
 import AdaApp
 import AdaAssets
 import AdaUI

--- a/Sources/AdaEngineEmbeddable/ApplePlatforms/AEView.swift
+++ b/Sources/AdaEngineEmbeddable/ApplePlatforms/AEView.swift
@@ -25,7 +25,7 @@ public final class AEView: MetalView {
     private let logger = Logger(label: "org.adaengine.AEView")
 
     /// Create AEView with AdaEngine.View.
-    public init(view: UIView, frame: CGRect) throws {
+    public init(view: AdaUI.UIView, frame: CGRect) throws {
         let rect = frame.toEngineRect
         
         /// We should avoid multiple instancing of this object
@@ -87,7 +87,7 @@ extension AEView: MTKViewDelegate {
 }
 
 private struct _EmbeddableApp: AdaApp.App {
-    let window: UIWindow
+    let window: AdaEngine.UIWindow
     
     var body: some AppScene {
         EmptyWindow()

--- a/Sources/AdaEngineEmbeddable/ApplePlatforms/AppleWindowManager.swift
+++ b/Sources/AdaEngineEmbeddable/ApplePlatforms/AppleWindowManager.swift
@@ -20,23 +20,23 @@ final class AppleWindowManager: UIWindowManager {
         self.screenManager = screenManager
     }
     
-    override func resizeWindow(_ window: UIWindow, size: Size) {
+    override func resizeWindow(_ window: AdaEngine.UIWindow, size: Size) {
         
     }
     
-    override func setWindowMode(_ window: UIWindow, mode: UIWindow.Mode) {
+    override func setWindowMode(_ window: AdaEngine.UIWindow, mode: AdaEngine.UIWindow.Mode) {
         
     }
     
-    override func closeWindow(_ window: UIWindow) {
+    override func closeWindow(_ window: AdaEngine.UIWindow) {
         
     }
     
-    override func showWindow(_ window: UIWindow, isFocused: Bool) {
+    override func showWindow(_ window: AdaEngine.UIWindow, isFocused: Bool) {
         
     }
     
-    override func setMinimumSize(_ size: Size, for window: UIWindow) {
+    override func setMinimumSize(_ size: Size, for window: AdaEngine.UIWindow) {
         
     }
     
@@ -44,7 +44,7 @@ final class AppleWindowManager: UIWindowManager {
         
     }
     
-    override func getScreen(for window: UIWindow) -> Screen? {
+    override func getScreen(for window: AdaEngine.UIWindow) -> Screen? {
         guard let nativeScreen = nativeView?.window?.screen else {
             return nil
         }

--- a/Sources/AdaEngineEmbeddable/PreviewScene/PreviewProvider.swift
+++ b/Sources/AdaEngineEmbeddable/PreviewScene/PreviewProvider.swift
@@ -5,7 +5,7 @@
 //  Created by Vladislav Prusakov on 20.02.2025.
 //
 
-#if canImport(SwiftUI) && swift(>=5.9)
+#if false && canImport(SwiftUI) && swift(>=5.9)
 
 import AdaEngine
 import SwiftUI


### PR DESCRIPTION
SPI builds failed for iOS/visionOS and tvOS. For that reason, our SPI badge shows only macOS builds. 