### PR TITLE
Move AdaUI State property to macro

### DIFF
--- a/Sources/AdaApp/AppScenes/AppScene.swift
+++ b/Sources/AdaApp/AppScenes/AppScene.swift
@@ -96,6 +96,21 @@ public extension AppScene {
         self.modifier(WindowTitleBarSceneModifier(titleBar: titleBar))
     }
 
+    /// Set the native platform window chrome style.
+    func windowChrome(_ chrome: WindowChrome) -> some AppScene {
+        self.modifier(WindowChromeSceneModifier(chrome: chrome))
+    }
+
+    /// Set the native platform window background style.
+    func windowBackground(_ background: WindowBackground) -> some AppScene {
+        self.modifier(WindowBackgroundSceneModifier(background: background))
+    }
+
+    /// Set whether the native platform window background should be transparent.
+    func windowTransparentBackground(_ isTransparent: Bool = true) -> some AppScene {
+        self.windowBackground(isTransparent ? .transparent : .opaque(.black))
+    }
+
     /// Offset macOS traffic light buttons. Positive `x` moves right, positive `y` moves down.
     func windowTrafficLightOffset(x: Float, y: Float) -> some AppScene {
         self.modifier(WindowTrafficLightOffsetSceneModifier(offset: Point(x: x, y: y)))

--- a/Sources/AdaApp/AppScenes/InternalAppScene.swift
+++ b/Sources/AdaApp/AppScenes/InternalAppScene.swift
@@ -42,6 +42,45 @@ public enum WindowTitleBarBackground: Sendable, Equatable {
     case transparent
 }
 
+/// Native platform window chrome style.
+public enum WindowChrome: Sendable, Equatable {
+    /// Use the platform default titled window chrome.
+    case standard
+
+    /// Use a borderless platform window.
+    case borderless
+}
+
+/// Native platform window background style.
+public enum WindowBackground: Sendable, Equatable {
+    /// Fill the platform window background with an opaque color.
+    case opaque(Color)
+
+    /// Make the platform window background transparent.
+    case transparent
+}
+
+/// Native platform window level.
+public enum WindowLevel: Sendable, Equatable {
+    /// Use the platform normal window level.
+    case normal
+
+    /// Keep the window above normal windows.
+    case floating
+
+    /// Use a status-bar-like high window level.
+    case statusBar
+}
+
+/// Native platform window collection behavior.
+public enum WindowCollectionBehavior: Sendable, Equatable {
+    /// Use the platform standard behavior.
+    case standard
+
+    /// Show the window on all spaces and keep it stationary.
+    case allSpacesStationary
+}
+
 /// Platform title bar presentation settings.
 public struct WindowTitleBar: Sendable, Equatable {
     /// The title bar background behavior.
@@ -84,6 +123,9 @@ public struct WindowSettings: Resource {
     /// The minimum size of the window.
     public var minimumSize: Size = Size(width: 800, height: 600)
 
+    /// Initial window content frame. If zero, the platform window manager uses `minimumSize`.
+    public var frame: Rect = .zero
+
     /// The mode of the window.
     public var windowMode: WindowMode = .fullscreen
 
@@ -101,6 +143,24 @@ public struct WindowSettings: Resource {
 
     /// Platform title bar presentation settings.
     public var titleBar: WindowTitleBar = .standard
+
+    /// Native platform window chrome style.
+    public var chrome: WindowChrome = .standard
+
+    /// Native platform window background style.
+    public var background: WindowBackground = .opaque(.black)
+
+    /// Native platform window level.
+    public var level: WindowLevel = .normal
+
+    /// Native platform window collection behavior.
+    public var collectionBehavior: WindowCollectionBehavior = .standard
+
+    /// Whether the platform window should be shown immediately.
+    public var showsImmediately: Bool = true
+
+    /// Whether the platform window should become key when shown.
+    public var makeKey: Bool = true
 
     /// Preferred display for the window.
     public var screenPreference: WindowScreenPreference?

--- a/Sources/AdaApp/AppScenes/SceneModifiers/DefaultSceneModifiers.swift
+++ b/Sources/AdaApp/AppScenes/SceneModifiers/DefaultSceneModifiers.swift
@@ -99,6 +99,24 @@ struct WindowTitleBarSceneModifier: SceneModifier {
     }
 }
 
+/// Set the native platform window chrome style.
+struct WindowChromeSceneModifier: SceneModifier {
+    let chrome: WindowChrome
+
+    func body(content: Content) -> some AppScene {
+        content.updateResource(of: WindowSettings.self, keyPath: \.chrome, value: chrome)
+    }
+}
+
+/// Set the native platform window background style.
+struct WindowBackgroundSceneModifier: SceneModifier {
+    let background: WindowBackground
+
+    func body(content: Content) -> some AppScene {
+        content.updateResource(of: WindowSettings.self, keyPath: \.background, value: background)
+    }
+}
+
 /// Offset macOS traffic light buttons.
 struct WindowTrafficLightOffsetSceneModifier: SceneModifier {
     let offset: Point

--- a/Sources/AdaEngineMacros/AdaEngineMacrosPlugin.swift
+++ b/Sources/AdaEngineMacros/AdaEngineMacrosPlugin.swift
@@ -15,6 +15,7 @@ struct AdaEngineMacrosPlugin: CompilerPlugin {
         EntryMacro.self,
         SystemMacro.self,
         BundleMacro.self,
-        PreviewableMacro.self
+        PreviewableMacro.self,
+        StateMacro.self
     ]
 }

--- a/Sources/AdaEngineMacros/StateMacro.swift
+++ b/Sources/AdaEngineMacros/StateMacro.swift
@@ -1,0 +1,182 @@
+//
+//  StateMacro.swift
+//  AdaEngineMacros
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct StateMacro { }
+
+extension StateMacro: AccessorMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingAccessorsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AccessorDeclSyntax] {
+        let property = try StateProperty(declaration: declaration, attribute: node)
+        let storageName = property.initialValue == nil ? "_\(property.name)" : "__\(property.name)"
+
+        let getAccessor: AccessorDeclSyntax = "get { \(raw: storageName).wrappedValue }"
+        let setAccessor: AccessorDeclSyntax = "nonmutating set { \(raw: storageName).wrappedValue = newValue }"
+        return [getAccessor, setAccessor]
+    }
+}
+
+extension StateMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        let property = try StateProperty(declaration: declaration, attribute: node)
+        let access = property.accessModifier
+        let typeAnnotation = property.type.map { ": \($0.trimmedDescription)" } ?? ""
+
+        let backingStorage: DeclSyntax
+        let storageName: String
+        if let initialValue = property.initialValue {
+            storageName = "__\(property.name)"
+            backingStorage =
+            """
+            private let __\(raw: property.name) = \(raw: property.qualifier)State._makeStorage({
+                let value\(raw: typeAnnotation) = \(initialValue)
+                return value
+            })
+            """
+        } else {
+            storageName = "_\(property.name)"
+            backingStorage =
+            """
+            private var _\(raw: property.name): \(raw: property.qualifier)State<\(property.valueType)>
+            """
+        }
+
+        let projectedValue: DeclSyntax =
+        """
+        \(raw: access)var $\(raw: property.name): \(raw: property.qualifier)Binding<\(property.valueType)> {
+            get {
+                \(raw: storageName).projectedValue
+            }
+        }
+        """
+
+        return [backingStorage, projectedValue]
+    }
+}
+
+private struct StateProperty {
+    let name: String
+    let type: TypeSyntax?
+    let initialValue: ExprSyntax?
+    let accessModifier: String
+    let valueType: TypeSyntax
+    let qualifier: String
+
+    init(declaration: some DeclSyntaxProtocol, attribute: AttributeSyntax) throws {
+        guard let variable = declaration.as(VariableDeclSyntax.self),
+              let binding = variable.bindings.first,
+              variable.bindings.count == 1 else {
+            throw MacroError.macroUsage("State macro can be applied only to a single stored property.")
+        }
+
+        guard let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
+            throw MacroError.macroUsage("State macro can be applied only to identifier properties.")
+        }
+
+        self.name = identifier
+        self.type = binding.typeAnnotation?.type
+        self.accessModifier = variable.stateAccessModifier
+        self.qualifier = attribute.stateQualifier
+
+        let initialValue: ExprSyntax?
+        if let value = binding.initializer?.value {
+            initialValue = value
+        } else if let attributeInitialValue = attribute.argument(for: "initialValue") ?? attribute.argument(for: "wrappedValue") {
+            initialValue = attributeInitialValue
+        } else if binding.typeAnnotation?.type.is(OptionalTypeSyntax.self) == true {
+            initialValue = "nil"
+        } else {
+            initialValue = nil
+        }
+
+        self.initialValue = initialValue
+        if let type = binding.typeAnnotation?.type {
+            self.valueType = type
+        } else if let inferredType = initialValue?.inferredStateValueType {
+            self.valueType = inferredType
+        } else {
+            throw MacroError.macroUsage("State macro requires an explicit type for uninitialized or non-literal initial values.")
+        }
+    }
+}
+
+private extension VariableDeclSyntax {
+    var stateAccessModifier: String {
+        if modifiers.contains(where: { $0.name.tokenKind == .keyword(.public) }) {
+            return "public "
+        }
+        if modifiers.contains(where: { $0.name.tokenKind == .keyword(.package) }) {
+            return "package "
+        }
+        if modifiers.contains(where: { $0.name.tokenKind == .keyword(.fileprivate) }) {
+            return "fileprivate "
+        }
+        if modifiers.contains(where: { $0.name.tokenKind == .keyword(.private) }) {
+            return "private "
+        }
+        return ""
+    }
+}
+
+private extension ExprSyntax {
+    var inferredStateValueType: TypeSyntax? {
+        if self.is(IntegerLiteralExprSyntax.self) {
+            return "Int"
+        }
+        if self.is(BooleanLiteralExprSyntax.self) {
+            return "Bool"
+        }
+        if self.is(StringLiteralExprSyntax.self) {
+            return "String"
+        }
+        if self.is(FloatLiteralExprSyntax.self) {
+            return "Double"
+        }
+        if let memberAccess = self.as(MemberAccessExprSyntax.self),
+           let base = memberAccess.base?.trimmedDescription,
+           !base.isEmpty {
+            return "\(raw: base)"
+        }
+        if let call = self.as(FunctionCallExprSyntax.self),
+           let calledType = call.calledExpression.constructorTypeName {
+            return calledType
+        }
+        return nil
+    }
+}
+
+private extension ExprSyntax {
+    var constructorTypeName: TypeSyntax? {
+        let typeName = trimmedDescription
+        guard !typeName.isEmpty,
+              typeName.split(separator: ".").last?.first?.isUppercase == true else {
+            return nil
+        }
+
+        return "\(raw: typeName)"
+    }
+}
+
+private extension AttributeSyntax {
+    var stateQualifier: String {
+        let name = attributeName.trimmedDescription
+        guard name.hasSuffix(".State"),
+              let dotIndex = name.lastIndex(of: ".") else {
+            return ""
+        }
+
+        return "\(name[..<name.index(after: dotIndex)])"
+    }
+}

--- a/Sources/AdaUI/DSL/PropertyWrappers/State.swift
+++ b/Sources/AdaUI/DSL/PropertyWrappers/State.swift
@@ -6,14 +6,13 @@
 //
 
 @MainActor
-@propertyWrapper
 public struct State<Value>: UpdatableProperty, PropertyStoragable {
     final class Handle {
         var storage: StateStorage<Value>?
-        let initialValue: Value
+        let makeInitialValue: (@MainActor () -> Value)?
 
-        init(initialValue: Value) {
-            self.initialValue = initialValue
+        init(makeInitialValue: (@MainActor () -> Value)?) {
+            self.makeInitialValue = makeInitialValue
         }
     }
 
@@ -39,21 +38,37 @@ public struct State<Value>: UpdatableProperty, PropertyStoragable {
     }
 
     public init(wrappedValue: Value) {
-        self.handle = Handle(initialValue: wrappedValue)
+        self.handle = Handle(makeInitialValue: { wrappedValue })
     }
 
     public init(initialValue: Value) {
-        self.handle = Handle(initialValue: initialValue)
+        self.handle = Handle(makeInitialValue: { initialValue })
     }
 
     public func update() { }
+
+    public static func _makeStorage(_ makeInitialValue: @escaping @MainActor () -> Value) -> State<Value> {
+        State(makeInitialValue: makeInitialValue)
+    }
+
+    public static func _makeStorage(initialValue: Value) -> State<Value> {
+        State(initialValue: initialValue)
+    }
+
+    private init(makeInitialValue: (@MainActor () -> Value)?) {
+        self.handle = Handle(makeInitialValue: makeInitialValue)
+    }
 
     private func currentStorage() -> StateStorage<Value> {
         if let storage = handle.storage {
             return storage
         }
 
-        let storage = StateStorage(value: handle.initialValue)
+        guard let makeInitialValue = handle.makeInitialValue else {
+            fatalError("State storage was read before it was initialized.")
+        }
+
+        let storage = StateStorage(value: makeInitialValue())
         handle.storage = storage
         return storage
     }
@@ -75,8 +90,27 @@ extension State: ViewStateBindable {
     func bind(to container: ViewStateContainer, key: ViewStatePropertyKey) {
         let storage = container.storage(
             for: key,
-            initialValue: self.handle.storage ?? StateStorage(value: handle.initialValue)
+            initialValue: self.handle.storage ?? StateStorage(value: initialValue())
         )
         self.handle.storage = storage
     }
+
+    private func initialValue() -> Value {
+        guard let makeInitialValue = handle.makeInitialValue else {
+            fatalError("State storage was bound before it was initialized.")
+        }
+        return makeInitialValue()
+    }
 }
+
+@attached(accessor, names: named(get), named(set))
+@attached(peer, names: prefixed(`_`), prefixed(`__`), prefixed(`$`))
+public macro State() = #externalMacro(module: "AdaEngineMacros", type: "StateMacro")
+
+@attached(accessor, names: named(get), named(set))
+@attached(peer, names: prefixed(`_`), prefixed(`__`), prefixed(`$`))
+public macro State<Value>(initialValue: Value) = #externalMacro(module: "AdaEngineMacros", type: "StateMacro")
+
+@attached(accessor, names: named(get), named(set))
+@attached(peer, names: prefixed(`_`), prefixed(`__`), prefixed(`$`))
+public macro State<Value>(wrappedValue: Value) = #externalMacro(module: "AdaEngineMacros", type: "StateMacro")

--- a/Sources/AdaUI/Plugins/UIPlugin.swift
+++ b/Sources/AdaUI/Plugins/UIPlugin.swift
@@ -96,23 +96,34 @@ public struct WindowPlugin: Plugin {
             let embeddedWindowSize = Screen.main?.size ?? windowSettings.minimumSize
             let configuration = UIWindow.Configuration(
                 title: windowSettings.title ?? "App",
-                frame: Rect(origin: .zero, size: embeddedWindowSize),
+                frame: windowSettings.frame,
                 minimumSize: embeddedWindowSize,
                 mode: .fullscreen,
+                chrome: UIWindow.Chrome(windowSettings.chrome),
                 titleBar: UIWindow.TitleBar(windowSettings.titleBar),
-                showsImmediately: false,
+                background: UIWindow.Background(windowSettings.background),
+                level: UIWindow.Level(windowSettings.level),
+                collectionBehavior: UIWindow.CollectionBehavior(windowSettings.collectionBehavior),
+                screenPreference: windowSettings.screenPreference,
+                showsImmediately: windowSettings.showsImmediately,
+                makeKey: windowSettings.makeKey,
                 hasShadow: windowSettings.hasShadow,
                 isResizable: windowSettings.isResizable
             )
             #else
             let configuration = UIWindow.Configuration(
                 title: windowSettings.title ?? "App",
-                frame: Rect(origin: .zero, size: windowSettings.minimumSize),
+                frame: windowSettings.frame,
                 minimumSize: windowSettings.minimumSize,
                 mode: UIWindow.Mode(windowSettings.windowMode),
+                chrome: UIWindow.Chrome(windowSettings.chrome),
                 titleBar: UIWindow.TitleBar(windowSettings.titleBar),
+                background: UIWindow.Background(windowSettings.background),
+                level: UIWindow.Level(windowSettings.level),
+                collectionBehavior: UIWindow.CollectionBehavior(windowSettings.collectionBehavior),
                 screenPreference: windowSettings.screenPreference,
-                showsImmediately: false,
+                showsImmediately: windowSettings.showsImmediately,
+                makeKey: windowSettings.makeKey,
                 hasShadow: windowSettings.hasShadow,
                 isResizable: windowSettings.isResizable
             )
@@ -121,7 +132,9 @@ public struct WindowPlugin: Plugin {
             #if WASM
             print("AdaEngine WindowPlugin created window")
             #endif
-            window.showWindow(makeFocused: true)
+            if configuration.showsImmediately {
+                window.showWindow(makeFocused: configuration.makeKey)
+            }
             app
                 .insertResource(PrimaryWindow(window: window))
                 .insertResource(PrimaryWindowId(windowId: window.id))
@@ -154,6 +167,52 @@ private extension UIWindow.Mode {
             self = .fullscreen
         case .fullScreenWindowed:
             self = .fullScreenWindowed
+        }
+    }
+}
+
+private extension UIWindow.Chrome {
+    init(_ chrome: WindowChrome) {
+        switch chrome {
+        case .standard:
+            self = .standard
+        case .borderless:
+            self = .borderless
+        }
+    }
+}
+
+private extension UIWindow.Background {
+    init(_ background: WindowBackground) {
+        switch background {
+        case .opaque(let color):
+            self = .opaque(color)
+        case .transparent:
+            self = .transparent
+        }
+    }
+}
+
+private extension UIWindow.Level {
+    init(_ level: WindowLevel) {
+        switch level {
+        case .normal:
+            self = .normal
+        case .floating:
+            self = .floating
+        case .statusBar:
+            self = .statusBar
+        }
+    }
+}
+
+private extension UIWindow.CollectionBehavior {
+    init(_ behavior: WindowCollectionBehavior) {
+        switch behavior {
+        case .standard:
+            self = .standard
+        case .allSpacesStationary:
+            self = .allSpacesStationary
         }
     }
 }

--- a/Sources/AdaUI/Plugins/WindowConfigurationSceneModifier.swift
+++ b/Sources/AdaUI/Plugins/WindowConfigurationSceneModifier.swift
@@ -1,0 +1,129 @@
+//
+//  WindowConfigurationSceneModifier.swift
+//  AdaEngine
+//
+//  Created by Sloppy on 2026-06-08.
+//
+
+import AdaApp
+import AdaECS
+import AdaUtils
+import Math
+
+public extension AppScene {
+    /// Configure the primary native platform window using a single configuration value.
+    func window(with configuration: UIWindow.Configuration) -> some AppScene {
+        self.modifier(WindowConfigurationSceneModifier(configuration: configuration))
+    }
+}
+
+/// Set the complete native platform window configuration.
+struct WindowConfigurationSceneModifier: SceneModifier {
+    let configuration: UIWindow.Configuration
+
+    func body(content: Content) -> some AppScene {
+        content.transformAppWorlds { worlds in
+            let resource = worlds.main.getRefResource(WindowSettings.self)
+            resource.wrappedValue.apply(configuration)
+        }
+    }
+}
+
+private extension WindowSettings {
+    mutating func apply(_ configuration: UIWindow.Configuration) {
+        self.title = configuration.title
+        self.frame = configuration.frame
+        self.minimumSize = configuration.minimumSize
+        self.windowMode = WindowMode(configuration.mode)
+        self.chrome = WindowChrome(configuration.chrome)
+        self.titleBar = WindowTitleBar(configuration.titleBar)
+        self.background = WindowBackground(configuration.background)
+        self.level = WindowLevel(configuration.level)
+        self.collectionBehavior = WindowCollectionBehavior(configuration.collectionBehavior)
+        self.screenPreference = configuration.screenPreference
+        self.showsImmediately = configuration.showsImmediately
+        self.makeKey = configuration.makeKey
+        self.hasShadow = configuration.hasShadow
+        self.isResizable = configuration.isResizable
+    }
+}
+
+private extension WindowMode {
+    init(_ mode: UIWindow.Mode) {
+        switch mode {
+        case .windowed:
+            self = .windowed
+        case .fullscreen:
+            self = .fullscreen
+        case .fullScreenWindowed:
+            self = .fullScreenWindowed
+        }
+    }
+}
+
+private extension WindowChrome {
+    init(_ chrome: UIWindow.Chrome) {
+        switch chrome {
+        case .standard:
+            self = .standard
+        case .borderless:
+            self = .borderless
+        }
+    }
+}
+
+private extension WindowBackground {
+    init(_ background: UIWindow.Background) {
+        switch background {
+        case .opaque(let color):
+            self = .opaque(color)
+        case .transparent:
+            self = .transparent
+        }
+    }
+}
+
+private extension WindowLevel {
+    init(_ level: UIWindow.Level) {
+        switch level {
+        case .normal:
+            self = .normal
+        case .floating:
+            self = .floating
+        case .statusBar:
+            self = .statusBar
+        }
+    }
+}
+
+private extension WindowCollectionBehavior {
+    init(_ behavior: UIWindow.CollectionBehavior) {
+        switch behavior {
+        case .standard:
+            self = .standard
+        case .allSpacesStationary:
+            self = .allSpacesStationary
+        }
+    }
+}
+
+private extension WindowTitleBar {
+    init(_ titleBar: UIWindow.TitleBar) {
+        switch titleBar.background {
+        case .system:
+            self.init(
+                background: .system,
+                reservesSafeArea: titleBar.reservesSafeArea,
+                dragRegionHeight: titleBar.dragRegionHeight,
+                trafficLightOffset: titleBar.trafficLightOffset
+            )
+        case .transparent:
+            self.init(
+                background: .transparent,
+                reservesSafeArea: titleBar.reservesSafeArea,
+                dragRegionHeight: titleBar.dragRegionHeight,
+                trafficLightOffset: titleBar.trafficLightOffset
+            )
+        }
+    }
+}

--- a/Tests/AdaUITests/ViewStoragesTests.swift
+++ b/Tests/AdaUITests/ViewStoragesTests.swift
@@ -103,6 +103,20 @@ struct ViewStoragesTests {
     }
 
     @Test
+    func stateInitialValue_isLazyUntilStateStorageIsRead() {
+        StateInitialValueProbe.initialValueEvaluations = 0
+
+        _ = StateInitialValueProbe()
+
+        #expect(StateInitialValueProbe.initialValueEvaluations == 0)
+    }
+
+    @Test
+    func stateMacro_infersTypeFromConstructorInitialValue() {
+        _ = ConstructedStateInitialValueProbe()
+    }
+
+    @Test
     func multipleStatesInOneView_doNotSwapAfterRebuild() {
         let recorder = StateIdentityRecorder()
         let tester = ViewTester(rootView: MultipleStateHost(recorder: recorder))
@@ -194,6 +208,33 @@ private final class BindingBox<Value> {
             get: { self.value },
             set: { self.value = $0 }
         )
+    }
+}
+
+private struct StateInitialValueProbe: View {
+    static var initialValueEvaluations = 0
+
+    @State private var value: Int = makeInitialValue()
+
+    static func makeInitialValue() -> Int {
+        initialValueEvaluations += 1
+        return 42
+    }
+
+    var body: some View {
+        Text("\(value)")
+    }
+}
+
+private struct ConstructedStateValue {
+    var count = 0
+}
+
+private struct ConstructedStateInitialValueProbe: View {
+    @State private var value = ConstructedStateValue()
+
+    var body: some View {
+        Text("\(value.count)")
     }
 }
 


### PR DESCRIPTION
Apple introduce State macro, that create lazy state and avoid some additional initialization. So, I've add the same behavior for AdaUI States and now, we use macro for that. 

It's a bit faster, than previous behaviour.